### PR TITLE
Add generate salt function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ export const hash:
     (plain: Buffer | string, salt: Buffer, options?: Options) => Promise<string>
     = argon2lib.hash;
 
+// This used to be defined in argon2lib.generateSalt but then being remove
+// https://github.com/ranisalt/node-argon2/commit/72fed64dc752a97613a0a63143b810b35ee69abf#diff-04c6e90faac2675aa89e2176d2eec7d8L24
 export async function generateSalt(length?: number): Promise<Buffer> {
     return new Promise((resolve, reject) => {
         crypto.randomBytes(length || 16, (err, salt) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,16 @@ export const hash:
     (plain: Buffer | string, salt: Buffer, options?: Options) => Promise<string>
     = argon2lib.hash;
 
-export const generateSalt:
-    (length?: number) => Promise<Buffer>
-    = argon2lib.generateSalt;
+export async function generateSalt(length?: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        crypto.randomBytes(length || 16, (err, salt) => {
+            if (err) {
+                reject(err);
+            }
+            resolve(salt);
+        })
+    })
+};
 
 export const verify:
     (hash: string, plain: Buffer | string) => Promise<boolean>

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export const hash:
 
 // This used to be defined in argon2lib.generateSalt but then being remove
 // https://github.com/ranisalt/node-argon2/commit/72fed64dc752a97613a0a63143b810b35ee69abf#diff-04c6e90faac2675aa89e2176d2eec7d8L24
-export async function generateSalt(length?: number): Promise<Buffer> {
+export function generateSalt(length?: number): Promise<Buffer> {
     return new Promise((resolve, reject) => {
         crypto.randomBytes(length || 16, (err, salt) => {
             if (err) {


### PR DESCRIPTION
We will need a completely migrate the hash function as well because we cannot pass the custom `salt` anymore...

But given we're no longer do local hash and prehash, this is just to make the test passed...

all the hashing logic still happen inside `pwhaas-js`, which we aren't going to changed. I think let's just add this function in and keep it the way it's for the rest...